### PR TITLE
Automatically Expand Paths of single children

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
@@ -250,12 +250,20 @@ public class PackageExplorerPart extends ViewPart
 
 
 	private class PackageExplorerProblemTreeViewer extends ProblemTreeViewer {
+		/**
+		 * Number of levels to automatically expand when an element only has a single
+		 * child.
+		 *
+		 * @see AbstractTreeViewer#setAutoExpandOnSingleChildLevels(int)
+		 */
+		private static final int AUTO_EXPAND_ON_SINGLE_CHILD_LEVELS= 10;
 		// fix for 64372  Projects showing up in Package Explorer twice [package explorer]
 		private final List<Object> fPendingRefreshes;
 
 		public PackageExplorerProblemTreeViewer(Composite parent, int style) {
 			super(parent, style);
 			fPendingRefreshes= Collections.synchronizedList(new ArrayList<>());
+			setAutoExpandOnSingleChildLevels(AUTO_EXPAND_ON_SINGLE_CHILD_LEVELS);
 		}
 		@Override
 		public void add(Object parentElement, Object... childElements) {


### PR DESCRIPTION
In the project explorer and similar treeviews, when expanding a folder that contains a singular folder, I expect that folder to recursively expand as well.

### Examples
In these cases, I expect all folders to open recursively
```
com.wittmaxi.plugin
 └─src
    └─org.foo.com
       └─Bar.java
```

#### In IntelliJ
(click on `src`)
![grafik](https://github.com/eclipse-platform/eclipse.platform.ui/assets/16443184/2c05bcf7-9765-479e-870a-3adead4ead50)

A few things are yet to be discussed (help wanted!):

- Should this be always enabled by default or should there be a preference to toggle this behavior?
- What should be the default "auto-expansion-depth"? 10 Nodes (as I have arbitrarily set it for this PR)? Or infinitely many? Should there be a preference for those values?

A similar PR was created in eclipse.platform  for the "project explorer": https://github.com/eclipse-platform/eclipse.platform.ui/pull/1742